### PR TITLE
Update Architectury Loom plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "architectury-plugin" version "3.4-SNAPSHOT"
-    id "dev.architectury.loom" version "1.6-SNAPSHOT" apply false
+    id "dev.architectury.loom" version "1.7-SNAPSHOT" apply false
 }
 
 architectury {


### PR DESCRIPTION
Bumped the dev.architectury.loom plugin version from 1.6-SNAPSHOT to 1.7-SNAPSHOT in build.gradle.

Everything should be functional, I've been testing with MTR. 