### PR TITLE
Update PieceLimitedJigsawManager.java to fix jigsaw placement

### DIFF
--- a/common/src/main/java/com/finndog/moogs_structures/world/structures/pieces/PieceLimitedJigsawManager.java
+++ b/common/src/main/java/com/finndog/moogs_structures/world/structures/pieces/PieceLimitedJigsawManager.java
@@ -9,13 +9,10 @@ import com.finndog.moogs_structures.utils.GeneralUtils;
 import com.finndog.moogs_structures.world.structures.GenericJigsawStructure;
 import com.google.common.collect.Queues;
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.core.BlockPos;
-import net.minecraft.core.Direction;
-import net.minecraft.core.Holder;
-import net.minecraft.core.QuartPos;
-import net.minecraft.core.Registry;
+import net.minecraft.core.*;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.data.worldgen.Pools;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.LevelHeightAccessor;
@@ -39,15 +36,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemp
 import net.minecraft.world.phys.AABB;
 import org.apache.commons.lang3.mutable.MutableObject;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiConsumer;
 
 /**
@@ -76,8 +65,9 @@ public class PieceLimitedJigsawManager {
             LiquidSettings liquidSettings,
             BiConsumer<StructurePiecesBuilder, List<PoolElementStructurePiece>> structureBoundsAdjuster
     ) {
-        // Get jigsaw pool registry
-        Registry<StructureTemplatePool> jigsawPoolRegistry = context.registryAccess().lookupOrThrow(Registries.TEMPLATE_POOL);
+        // 1.21.5: resolve pools through HolderGetter (reload-scoped)
+        HolderGetter<StructureTemplatePool> poolLookup =
+                context.registryAccess().lookupOrThrow(Registries.TEMPLATE_POOL);
 
         // Get a random orientation for the starting piece
         WorldgenRandom random = new WorldgenRandom(new LegacyRandomSource(0L));
@@ -86,9 +76,10 @@ public class PieceLimitedJigsawManager {
 
         // Get starting pool
         StructureTemplatePool startPool = startPoolHolder.value();
-        if(startPool.size() == 0) {
-            MoogsStructuresCommon.LOGGER.warn("Moog's Structure Lib: Empty or nonexistent start pool in structure: {}  Crash is imminent", structureID);
-            throw new RuntimeException("Moog's Structure Lib: Empty or nonexistent start pool in structure: " + structureID + " Crash is imminent");
+        if (startPool.size() == 0) {
+            ResourceLocation startKey = startPoolHolder.unwrapKey().map(ResourceKey::location).orElse(structureID);
+            MoogsStructuresCommon.LOGGER.warn("Moog's Structure Lib: Empty or nonexistent start pool in structure: {}  Crash is imminent", startKey);
+            throw new RuntimeException("Moog's Structure Lib: Empty or nonexistent start pool in structure: " + startKey + " Crash is imminent");
         }
 
         // Grab a random starting piece from the start pool. This is just the piece design itself, without rotation or position information.
@@ -114,7 +105,8 @@ public class PieceLimitedJigsawManager {
         int pieceCenterX = (pieceBoundingBox.maxX() + pieceBoundingBox.minX()) / 2;
         int pieceCenterZ = (pieceBoundingBox.maxZ() + pieceBoundingBox.minZ()) / 2;
         int pieceCenterY = heightmapType
-                .map(types -> startPos.getY() + context.chunkGenerator().getFirstFreeHeight(pieceCenterX, pieceCenterZ, types, context.heightAccessor(), context.randomState()))
+                .map(types -> startPos.getY() + context.chunkGenerator().getFirstFreeHeight(
+                        pieceCenterX, pieceCenterZ, types, context.heightAccessor(), context.randomState()))
                 .orElseGet(startPos::getY);
 
         if (heightmapType.isPresent() && (pieceCenterY > maxY || pieceCenterY < minY)) {
@@ -123,115 +115,129 @@ public class PieceLimitedJigsawManager {
 
         int yAdjustment = pieceBoundingBox.minY() + startPiece.getGroundLevelDelta();
         startPiece.move(0, pieceCenterY - yAdjustment, 0);
-        if (!context.validBiome().test(context.chunkGenerator().getBiomeSource().getNoiseBiome(QuartPos.fromBlock(pieceCenterX), QuartPos.fromBlock(pieceCenterY), QuartPos.fromBlock(pieceCenterZ), context.randomState().sampler()))) {
+        if (!context.validBiome().test(context.chunkGenerator().getBiomeSource().getNoiseBiome(
+                QuartPos.fromBlock(pieceCenterX),
+                QuartPos.fromBlock(pieceCenterY),
+                QuartPos.fromBlock(pieceCenterZ),
+                context.randomState().sampler()))) {
             return Optional.empty();
         }
 
-        return Optional.of(new Structure.GenerationStub(new BlockPos(pieceCenterX, pieceCenterY, pieceCenterZ), (structurePiecesBuilder) -> {
-            List<PoolElementStructurePiece> components = new ArrayList<>();
-            components.add(startPiece);
-            Map<ResourceLocation, StructurePieceCountsManager.RequiredPieceNeeds> requiredPieces = StructurePieceCountsManager.STRUCTURE_PIECE_COUNTS_MANAGER.getRequirePieces(structureID);
-            boolean runOnce = requiredPieces == null || requiredPieces.isEmpty();
-            Map<ResourceLocation, Integer> currentPieceCounter = new HashMap<>();
-            for (int attempts = 0; runOnce || doesNotHaveAllRequiredPieces(components, requiredPieces, currentPieceCounter); attempts++) {
-                if (attempts == 100) {
-                    MoogsStructuresCommon.LOGGER.error(
-                            """
-                                            
+        return Optional.of(new Structure.GenerationStub(
+                new BlockPos(pieceCenterX, pieceCenterY, pieceCenterZ),
+                (structurePiecesBuilder) -> {
+                    List<PoolElementStructurePiece> components = new ArrayList<>();
+                    components.add(startPiece);
+
+                    Map<ResourceLocation, StructurePieceCountsManager.RequiredPieceNeeds> requiredPieces =
+                            StructurePieceCountsManager.STRUCTURE_PIECE_COUNTS_MANAGER.getRequirePieces(structureID);
+                    boolean runOnce = requiredPieces == null || requiredPieces.isEmpty();
+                    Map<ResourceLocation, Integer> currentPieceCounter = new HashMap<>();
+
+                    for (int attempts = 0; runOnce || doesNotHaveAllRequiredPieces(components, requiredPieces, currentPieceCounter); attempts++) {
+                        if (attempts == 100) {
+                            ResourceLocation startKey = startPoolHolder.unwrapKey().map(ResourceKey::location).orElse(structureID);
+                            MoogsStructuresCommon.LOGGER.error("""
+                                    
                                     -------------------------------------------------------------------
                                     Moog's Structure Lib: Failed to create valid structure with all required pieces starting from this pool file: {}. Required pieces failed to generate the required amount are: {}
                                       This can happen if a structure has a required piece but the structure size is set too low.
                                       However, this is most likely caused by a structure unable to spawn properly due to hitting the world's min y or max y build thresholds or a broken MoogsStructures datapack.
                                       Try teleporting to: {} and see if the structure generated fine with the required structure piece or if it is indeed missing it.
                                       Please report the issue to Moog's Structure Lib's dev with latest.log file if the structure is not cut off by world min/max y build thresholds.
-                                            
+                                    
                                     """,
-                            jigsawPoolRegistry.getKey(startPool), Arrays.toString(currentPieceCounter.entrySet().stream().filter(entry -> entry.getValue() > 0).toArray()), new BlockPos(pieceCenterX, pieceCenterY, pieceCenterZ));
-                    break;
-                }
+                                    startKey,
+                                    Arrays.toString(currentPieceCounter.entrySet().stream().filter(e -> e.getValue() > 0).toArray()),
+                                    new BlockPos(pieceCenterX, pieceCenterY, pieceCenterZ));
+                            break;
+                        }
 
-                //reroll start piece
-                PoolElementStructurePiece startPieceToUse = startPiece;
-                if (attempts > 0) {
-                    StructurePoolElement startPieceBlueprintNew = startPool.getRandomTemplate(random);
-                    startPieceToUse = new PoolElementStructurePiece(
-                            context.structureTemplateManager(),
-                            startPieceBlueprintNew,
-                            startPiece.getPosition(),
-                            startPieceBlueprintNew.getGroundLevelDelta(),
-                            startPiece.getRotation(),
-                            startPieceBlueprintNew.getBoundingBox(context.structureTemplateManager(), startPiece.getPosition(), startPiece.getRotation()),
-                            liquidSettings
-                    );
-                }
+                        // Reroll start piece if needed
+                        PoolElementStructurePiece startPieceToUse = startPiece;
+                        if (attempts > 0) {
+                            StructurePoolElement startPieceBlueprintNew = startPool.getRandomTemplate(random);
+                            startPieceToUse = new PoolElementStructurePiece(
+                                    context.structureTemplateManager(),
+                                    startPieceBlueprintNew,
+                                    startPiece.getPosition(),
+                                    startPieceBlueprintNew.getGroundLevelDelta(),
+                                    startPiece.getRotation(),
+                                    startPieceBlueprintNew.getBoundingBox(context.structureTemplateManager(), startPiece.getPosition(), startPiece.getRotation()),
+                                    liquidSettings
+                            );
+                        }
 
-                components.clear();
-                components.add(startPiece); // Add start piece to list of pieces
+                        components.clear();
+                        components.add(startPiece); // start stays
 
-                if (size > 0) {
-                    int boxRange = maxDistanceFromCenter.orElse(80);
-                    AABB axisAlignedBB = new AABB(pieceCenterX - boxRange, pieceCenterY - 120, pieceCenterZ - boxRange, pieceCenterX + boxRange + 1, pieceCenterY + 180 + 1, pieceCenterZ + boxRange + 1);
-                    BoxOctree boxOctree = new BoxOctree(axisAlignedBB); // The maximum boundary of the entire structure
-                    boxOctree.addBox(AABB.of(pieceBoundingBox));
-                    Entry startPieceEntry = new Entry(startPiece, new MutableObject<>(boxOctree), pieceCenterY + 80, 0);
+                        if (size > 0) {
+                            int boxRange = maxDistanceFromCenter.orElse(80);
+                            AABB axisAlignedBB = new AABB(
+                                    pieceCenterX - boxRange, pieceCenterY - 120, pieceCenterZ - boxRange,
+                                    pieceCenterX + boxRange + 1, pieceCenterY + 180 + 1, pieceCenterZ + boxRange + 1
+                            );
+                            BoxOctree boxOctree = new BoxOctree(axisAlignedBB);
+                            boxOctree.addBox(AABB.of(pieceBoundingBox));
+                            Entry startPieceEntry = new Entry(startPieceToUse, new MutableObject<>(boxOctree), pieceCenterY + 80, 0);
 
-                    Assembler assembler = new Assembler(
-                            structureID,
-                            jigsawPoolRegistry,
-                            size,
-                            context,
-                            components,
-                            random,
-                            requiredPieces,
-                            buryingType.isEmpty() ? maxY : Integer.MAX_VALUE,
-                            buryingType.isEmpty() ? minY : Integer.MIN_VALUE,
-                            poolsThatIgnoreBounds,
-                            liquidSettings);
-                    assembler.availablePieces.addLast(startPieceEntry);
+                            Assembler assembler = new Assembler(
+                                    structureID,
+                                    poolLookup, // 1.21.5 holder lookup
+                                    size,
+                                    context,
+                                    components,
+                                    random,
+                                    requiredPieces,
+                                    buryingType.isEmpty() ? maxY : Integer.MAX_VALUE,
+                                    buryingType.isEmpty() ? minY : Integer.MIN_VALUE,
+                                    poolsThatIgnoreBounds,
+                                    liquidSettings
+                            );
+                            assembler.availablePieces.addLast(startPieceEntry);
 
-                    while (!assembler.availablePieces.isEmpty()) {
-                        Entry entry = assembler.availablePieces.removeFirst();
-                        assembler.generatePiece(entry.piece, entry.boxOctreeMutableObject, entry.topYLimit, entry.depth, doBoundaryAdjustments, context.heightAccessor());
+                            while (!assembler.availablePieces.isEmpty()) {
+                                Entry entry = assembler.availablePieces.removeFirst();
+                                assembler.generatePiece(entry.piece, entry.boxOctreeMutableObject, entry.topYLimit, entry.depth, doBoundaryAdjustments, context.heightAccessor());
+                            }
+                        }
+
+                        if (runOnce) break;
+                    }
+
+                    components.forEach(structurePiecesBuilder::addPiece);
+                    structureBoundsAdjuster.accept(structurePiecesBuilder, components);
+
+                    // Do not generate if out of bounds
+                    if (structurePiecesBuilder.getBoundingBox().maxY() > context.heightAccessor().getMaxY()) {
+                        structurePiecesBuilder.clear();
                     }
                 }
-
-                if (runOnce) break;
-            }
-
-            components.forEach(structurePiecesBuilder::addPiece);
-            structureBoundsAdjuster.accept(structurePiecesBuilder, components);
-
-            // Do not generate if out of bounds
-            if(structurePiecesBuilder.getBoundingBox().maxY() > context.heightAccessor().getMaxY()) {
-                structurePiecesBuilder.clear();
-            }
-        }));
+        ));
     }
 
-    private static boolean doesNotHaveAllRequiredPieces(List<? extends StructurePiece> components, 
+    private static boolean doesNotHaveAllRequiredPieces(List<? extends StructurePiece> components,
                                                         Map<ResourceLocation, StructurePieceCountsManager.RequiredPieceNeeds> requiredPieces,
-                                                        Map<ResourceLocation, Integer> counter
-    ) {
+                                                        Map<ResourceLocation, Integer> counter) {
         counter.clear();
         requiredPieces.forEach((key, value) -> counter.put(key, value.getRequiredAmount()));
-        for(Object piece : components) {
-            if(piece instanceof PoolElementStructurePiece) {
-                StructurePoolElement poolElement = ((PoolElementStructurePiece)piece).getElement();
-                if(poolElement instanceof SinglePoolElement) {
+        for (Object piece : components) {
+            if (piece instanceof PoolElementStructurePiece p) {
+                StructurePoolElement poolElement = p.getElement();
+                if (poolElement instanceof SinglePoolElement spe) {
                     ResourceLocation pieceID = ((SinglePoolElementAccessor) poolElement).moogs_structures_getTemplate().left().orElse(null);
-                    if(counter.containsKey(pieceID)) {
+                    if (pieceID != null && counter.containsKey(pieceID)) {
                         counter.put(pieceID, counter.get(pieceID) - 1);
                     }
                 }
             }
         }
-
         return counter.values().stream().anyMatch(count -> count > 0);
     }
 
-
     public static final class Assembler {
-        private final Registry<StructureTemplatePool> poolRegistry;
+        // 1.21.5: use HolderGetter instead of Registry for pools
+        private final HolderGetter<StructureTemplatePool> poolLookup;
         private final int maxDepth;
         private final Structure.GenerationContext context;
         private final List<? super PoolElementStructurePiece> structurePieces;
@@ -245,9 +251,8 @@ public class PieceLimitedJigsawManager {
         private final Set<ResourceLocation> poolsThatIgnoreBounds;
         private final LiquidSettings liquidSettings;
 
-
         public Assembler(ResourceLocation structureID,
-                         Registry<StructureTemplatePool> poolRegistry,
+                         HolderGetter<StructureTemplatePool> poolLookup,
                          int maxDepth,
                          Structure.GenerationContext context,
                          List<? super PoolElementStructurePiece> structurePieces,
@@ -256,9 +261,8 @@ public class PieceLimitedJigsawManager {
                          int maxY,
                          int minY,
                          Set<ResourceLocation> poolsThatIgnoreBounds,
-                         LiquidSettings liquidSettings
-        ) {
-            this.poolRegistry = poolRegistry;
+                         LiquidSettings liquidSettings) {
+            this.poolLookup = poolLookup;
             this.maxDepth = maxDepth;
             this.context = context;
             this.structurePieces = structurePieces;
@@ -278,14 +282,14 @@ public class PieceLimitedJigsawManager {
             this.maximumPieceCounts.forEach((key, value) -> this.currentPieceCounts.putIfAbsent(key, 0));
         }
 
-        public void generatePiece(PoolElementStructurePiece piece, 
-                                  MutableObject<BoxOctree> boxOctree, 
-                                  int minY, 
+        public void generatePiece(PoolElementStructurePiece piece,
+                                  MutableObject<BoxOctree> boxOctree,
+                                  int minY,
                                   int depth,
                                   boolean doBoundaryAdjustments,
-                                  LevelHeightAccessor heightLimitView
-        ) {
             // Collect data from params regarding piece to process
+                                  LevelHeightAccessor heightLimitView) {
+
             StructurePoolElement pieceBlueprint = piece.getElement();
             BlockPos piecePos = piece.getPosition();
             Rotation pieceRotation = piece.getRotation();
@@ -294,7 +298,8 @@ public class PieceLimitedJigsawManager {
             MutableObject<BoxOctree> parentOctree = new MutableObject<>();
 
             // Get list of all jigsaw blocks in this piece
-            List<StructureTemplate.JigsawBlockInfo> pieceJigsawBlocks = pieceBlueprint.getShuffledJigsawBlocks(context.structureTemplateManager(), piecePos, pieceRotation, this.random);
+            List<StructureTemplate.JigsawBlockInfo> pieceJigsawBlocks =
+                    pieceBlueprint.getShuffledJigsawBlocks(context.structureTemplateManager(), piecePos, pieceRotation, this.random);
 
             for (StructureTemplate.JigsawBlockInfo jigsawBlock : pieceJigsawBlocks) {
                 // Gather jigsaw block information
@@ -303,17 +308,45 @@ public class PieceLimitedJigsawManager {
                 BlockPos jigsawBlockTargetPos = jigsawBlockPos.relative(direction);
 
                 // Get the jigsaw block's piece pool
-                ResourceLocation jigsawBlockPool = ResourceLocation.tryParse(String.valueOf(jigsawBlock.info().nbt().getString("pool")));
-                Optional<StructureTemplatePool> poolOptional = this.poolRegistry.getOptional(jigsawBlockPool);
+                // Resolve pool from NBT via HolderGetter
+                String poolStr = jigsawBlock.info().nbt().getString("pool").get();
+                ResourceLocation poolId = ResourceLocation.tryParse(poolStr);
+                if (poolId == null) {
+                    MoogsStructuresCommon.LOGGER.warn("Invalid pool id in jigsaw NBT: '{}'", poolStr);
+                    continue;
+                }
+                ResourceKey<StructureTemplatePool> poolKey =
+                        ResourceKey.create(Registries.TEMPLATE_POOL, poolId);
+
+                Optional<Holder.Reference<StructureTemplatePool>> optPoolRef = this.poolLookup.get(poolKey);
+                if (optPoolRef.isEmpty()) {
+                    MoogsStructuresCommon.LOGGER.warn(
+                            "Moog's Structure Lib: Missing pool {} called from {}",
+                            poolId,
+                            (pieceBlueprint instanceof SinglePoolElement spe)
+                                    ? ((SinglePoolElementAccessor) pieceBlueprint).moogs_structures_getTemplate().left().orElse(null)
+                                    : "not SinglePoolElement");
+                    continue;
+                }
 
                 // Only continue if we are using the jigsaw pattern registry and if it is not empty
-                if (!(poolOptional.isPresent() && (poolOptional.get().size() != 0 || Objects.equals(jigsawBlockPool, Pools.EMPTY.location())))) {
-                    MoogsStructuresCommon.LOGGER.warn("Moog's Structure Lib: Empty or nonexistent pool: {} which is being called from {}", jigsawBlockPool, pieceBlueprint instanceof SinglePoolElement ? ((SinglePoolElementAccessor) pieceBlueprint).moogs_structures_getTemplate().left().get() : "not a SinglePoolElement class");
+                StructureTemplatePool pool = optPoolRef.get().value();
+
+                boolean isEmptyPool = pool.size() == 0;
+                boolean isExplicitEmpty = poolKey.location().equals(Pools.EMPTY.location());
+                if (isEmptyPool && !isExplicitEmpty) {
+                    MoogsStructuresCommon.LOGGER.warn(
+                            "Moog's Structure Lib: Empty pool {} called from {}",
+                            poolId,
+                            (pieceBlueprint instanceof SinglePoolElement spe)
+                                    ? ((SinglePoolElementAccessor) pieceBlueprint).moogs_structures_getTemplate().left().orElse(null)
+                                    : "not SinglePoolElement");
                     continue;
                 }
 
                 // Get the jigsaw block's fallback pool (which is a part of the pool's JSON)
-                Holder<StructureTemplatePool> jigsawBlockFallback = poolOptional.get().getFallback();
+                // Fallback is a Holder now
+                Holder<StructureTemplatePool> jigsawBlockFallback = pool.getFallback();
 
                 // Adjustments for if the target block position is inside the current piece
                 boolean isTargetInsideCurrentPiece = pieceBoundingBox.isInside(jigsawBlockTargetPos);
@@ -325,25 +358,63 @@ public class PieceLimitedJigsawManager {
                     if (parentOctree.getValue() == null) {
                         parentOctree.setValue(new BoxOctree(AABB.of(pieceBoundingBox)));
                     }
-                }
-                else {
+                } else {
                     octreeToUse = boxOctree;
                     targetPieceBoundsTop = minY;
                 }
 
                 // Process the pool pieces, randomly choosing different pieces from the pool to spawn
                 if (depth != this.maxDepth) {
-                    StructurePoolElement generatedPiece = this.processList(new ArrayList<>(((StructurePoolAccessor)poolOptional.get()).moogs_structures_getRawTemplates()), doBoundaryAdjustments, jigsawBlock, jigsawBlockTargetPos, pieceMinY, jigsawBlockPos, octreeToUse, piece, depth, targetPieceBoundsTop, heightLimitView, false);
-                    if (generatedPiece != null) continue; // Stop here since we've already generated the piece
+                    List<Pair<StructurePoolElement, Integer>> elements =
+                            new ArrayList<>(((StructurePoolAccessor) pool).moogs_structures_getRawTemplates());
+
+                    StructurePoolElement generatedPiece =
+                            this.processList(
+                                    elements,
+                                    doBoundaryAdjustments,
+                                    jigsawBlock,
+                                    jigsawBlockTargetPos,
+                                    pieceMinY,
+                                    jigsawBlockPos,
+                                    octreeToUse,
+                                    piece,
+                                    depth,
+                                    targetPieceBoundsTop,
+                                    heightLimitView,
+                                    false
+                            );
+                    if (generatedPiece != null) continue;
                 }
 
                 // Process the fallback pieces in the event none of the pool pieces work
                 boolean ignoreBounds = false;
-                if(poolsThatIgnoreBounds != null) {
-                    ResourceLocation fallBackPoolRL = poolRegistry.getKey(jigsawBlockFallback.value());
-                    ignoreBounds = poolsThatIgnoreBounds.contains(fallBackPoolRL);
+                if (poolsThatIgnoreBounds != null) {
+                    ResourceLocation fallbackPoolId = jigsawBlockFallback.unwrapKey()
+                            .map(ResourceKey::location)
+                            .orElse(null);
+                    if (fallbackPoolId != null) {
+                        ignoreBounds = poolsThatIgnoreBounds.contains(fallbackPoolId);
+                    }
                 }
-                this.processList(new ArrayList<>(((StructurePoolAccessor)jigsawBlockFallback.value()).moogs_structures_getRawTemplates()), doBoundaryAdjustments, jigsawBlock, jigsawBlockTargetPos, pieceMinY, jigsawBlockPos, octreeToUse, piece, depth, targetPieceBoundsTop, heightLimitView, ignoreBounds);
+
+                StructureTemplatePool fallbackPool = jigsawBlockFallback.value();
+                List<Pair<StructurePoolElement, Integer>> fallbackElements =
+                        new ArrayList<>(((StructurePoolAccessor) fallbackPool).moogs_structures_getRawTemplates());
+
+                this.processList(
+                        fallbackElements,
+                        doBoundaryAdjustments,
+                        jigsawBlock,
+                        jigsawBlockTargetPos,
+                        pieceMinY,
+                        jigsawBlockPos,
+                        octreeToUse,
+                        piece,
+                        depth,
+                        targetPieceBoundsTop,
+                        heightLimitView,
+                        ignoreBounds
+                );
             }
         }
 
@@ -381,10 +452,11 @@ public class PieceLimitedJigsawManager {
                 // 3. We are at least certain amount of pieces away from the starting piece.
                 Pair<StructurePoolElement, Integer> chosenPiecePair = null;
                 // Condition 2
+
                 Optional<ResourceLocation> pieceNeededToSpawn = this.requiredPieces.keySet().stream().filter(key -> {
                     int currentCount = this.currentPieceCounts.get(key);
-                    StructurePieceCountsManager.RequiredPieceNeeds requiredPieceNeeds = this.requiredPieces.get(key);
-                    int requireCount = requiredPieceNeeds == null ? 0 : requiredPieceNeeds.getRequiredAmount();
+                    StructurePieceCountsManager.RequiredPieceNeeds needs = this.requiredPieces.get(key);
+                    int requireCount = needs == null ? 0 : needs.getRequiredAmount();
                     return currentCount < requireCount;
                 }).findFirst();
 
@@ -392,13 +464,13 @@ public class PieceLimitedJigsawManager {
                     for (int i = 0; i < candidatePieces.size(); i++) {
                         Pair<StructurePoolElement, Integer> candidatePiecePair = candidatePieces.get(i);
                         StructurePoolElement candidatePiece = candidatePiecePair.getFirst();
-                        if (candidatePiece instanceof SinglePoolElement && ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().get().equals(pieceNeededToSpawn.get())) { // Condition 1
-                            if (depth >= Math.min(maxDepth - 1, this.requiredPieces.get(pieceNeededToSpawn.get()).getMinDistanceFromCenter())) { // Condition 3
-                                // All conditions are met. Use required piece  as chosen piece.
+                        if (candidatePiece instanceof SinglePoolElement
+                                && ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().orElse(null) != null
+                                && ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().get().equals(pieceNeededToSpawn.get())) {
+                            if (depth >= Math.min(maxDepth - 1, this.requiredPieces.get(pieceNeededToSpawn.get()).getMinDistanceFromCenter())) {
                                 chosenPiecePair = candidatePiecePair;
-                            }
-                            else {
                                 // If not far enough from starting room, remove the required piece from the list
+                            } else {
                                 totalCount -= candidatePiecePair.getSecond();
                                 candidatePieces.remove(candidatePiecePair);
                             }
@@ -430,22 +502,24 @@ public class PieceLimitedJigsawManager {
                 // Before performing any logic, check to ensure we haven't reached the max number of instances of this piece.
                 // This logic is my own additional logic - vanilla does not offer this behavior.
                 ResourceLocation pieceName = null;
-                if(candidatePiece instanceof SinglePoolElement) {
-                    pieceName = ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().get();
-                    if (this.currentPieceCounts.containsKey(pieceName) && this.maximumPieceCounts.containsKey(pieceName)) {
-                        if (this.currentPieceCounts.get(pieceName) >= this.maximumPieceCounts.get(pieceName)) {
-                            // Remove this piece from the list of candidates and retry.
-                            totalCount -= chosenPiecePair.getSecond();
-                            candidatePieces.remove(chosenPiecePair);
-                            continue;
-                        }
+                if (candidatePiece instanceof SinglePoolElement) {
+                    pieceName = ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().orElse(null);
+                    if (pieceName != null
+                            && this.currentPieceCounts.containsKey(pieceName)
+                            && this.maximumPieceCounts.containsKey(pieceName)
+                            && this.currentPieceCounts.get(pieceName) >= this.maximumPieceCounts.get(pieceName)) {
+                        totalCount -= chosenPiecePair.getSecond();
+                        candidatePieces.remove(chosenPiecePair);
+                        continue;
                     }
                 }
 
                 // Try different rotations to see which sides of the piece are fit to be the receiving end
                 for (Rotation rotation : Rotation.getShuffled(this.random)) {
-                    List<StructureTemplate.JigsawBlockInfo> candidateJigsawBlocks = candidatePiece.getShuffledJigsawBlocks(context.structureTemplateManager(), BlockPos.ZERO, rotation, this.random);
-                    BoundingBox tempCandidateBoundingBox = candidatePiece.getBoundingBox(context.structureTemplateManager(), BlockPos.ZERO, rotation);
+                    List<StructureTemplate.JigsawBlockInfo> candidateJigsawBlocks =
+                            candidatePiece.getShuffledJigsawBlocks(context.structureTemplateManager(), BlockPos.ZERO, rotation, this.random);
+                    BoundingBox tempCandidateBoundingBox =
+                            candidatePiece.getBoundingBox(context.structureTemplateManager(), BlockPos.ZERO, rotation);
 
                     // Some sort of logic for setting the candidateHeightAdjustments var if doBoundaryAdjustments.
                     int candidateHeightAdjustments;
@@ -453,20 +527,29 @@ public class PieceLimitedJigsawManager {
                         candidateHeightAdjustments = candidateJigsawBlocks.stream().mapToInt((pieceCandidateJigsawBlock) -> {
                             if (!tempCandidateBoundingBox.isInside(pieceCandidateJigsawBlock.info().pos().relative(JigsawBlock.getFrontFacing(pieceCandidateJigsawBlock.info().state())))) {
                                 return 0;
-                            }
-                            else {
-                                ResourceLocation candidateTargetPool = ResourceLocation.tryParse(String.valueOf(pieceCandidateJigsawBlock.info().nbt().getString("pool")));
-                                Optional<StructureTemplatePool> candidateTargetPoolOptional = this.poolRegistry.getOptional(candidateTargetPool);
-                                if (candidateTargetPoolOptional.isEmpty()) {
-                                    MoogsStructuresCommon.LOGGER.warn("Moog's Structure Lib: Non-existent child pool attempted to be spawned: {} which is being called from {}. Let Moog's Structure Lib dev (FinnDog) know about this log entry.", candidateTargetPool, candidatePiece instanceof SinglePoolElement ? ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().get() : "not a SinglePoolElement class");
+                            } else {
+                                String tgt = pieceCandidateJigsawBlock.info().nbt().getString("pool").get();
+                                ResourceLocation targetPoolId = ResourceLocation.tryParse(tgt);
+                                if (targetPoolId == null) return 0;
+                                ResourceKey<StructureTemplatePool> targetKey =
+                                        ResourceKey.create(Registries.TEMPLATE_POOL, targetPoolId);
+                                Optional<Holder.Reference<StructureTemplatePool>> candOpt = this.poolLookup.get(targetKey);
+                                if (candOpt.isEmpty()) {
+                                    MoogsStructuresCommon.LOGGER.warn(
+                                            "Moog's Structure Lib: Non-existent child pool attempted to be spawned: {} which is being called from {}. Let Moog's Structure Lib dev (FinnDog) know about this log entry.",
+                                            targetPoolId,
+                                            candidatePiece instanceof SinglePoolElement spe
+                                                    ? ((SinglePoolElementAccessor) candidatePiece).moogs_structures_getTemplate().left().orElse(null)
+                                                    : "not SinglePoolElement");
+                                    return 0;
                                 }
-                                int tallestCandidateTargetFallbackPieceHeight = candidateTargetPoolOptional.map((c) -> c.getFallback().value().getMaxSize(context.structureTemplateManager())).orElse(0);
-                                int tallestCandidateTargetPoolPieceHeight = candidateTargetPoolOptional.map((c) -> c.getMaxSize(context.structureTemplateManager())).orElse(0);
-                                return Math.max(tallestCandidateTargetPoolPieceHeight, tallestCandidateTargetFallbackPieceHeight);
+                                StructureTemplatePool candPool = candOpt.get().value();
+                                int tallestFallback = candPool.getFallback().value().getMaxSize(context.structureTemplateManager());
+                                int tallestPool = candPool.getMaxSize(context.structureTemplateManager());
+                                return Math.max(tallestPool, tallestFallback);
                             }
                         }).max().orElse(0);
-                    } 
-                    else {
+                    } else {
                         candidateHeightAdjustments = 0;
                     }
 
@@ -474,30 +557,35 @@ public class PieceLimitedJigsawManager {
                     for (StructureTemplate.JigsawBlockInfo candidateJigsawBlock : candidateJigsawBlocks) {
                         if (GeneralUtils.canJigsawsAttach(jigsawBlock.info(), candidateJigsawBlock.info())) {
                             BlockPos candidateJigsawBlockPos = candidateJigsawBlock.info().pos();
-                            BlockPos candidateJigsawBlockRelativePos = new BlockPos(jigsawBlockTargetPos.getX() - candidateJigsawBlockPos.getX(), jigsawBlockTargetPos.getY() - candidateJigsawBlockPos.getY(), jigsawBlockTargetPos.getZ() - candidateJigsawBlockPos.getZ());
+                            BlockPos candidateJigsawBlockRelativePos = new BlockPos(
+                                    jigsawBlockTargetPos.getX() - candidateJigsawBlockPos.getX(),
+                                    jigsawBlockTargetPos.getY() - candidateJigsawBlockPos.getY(),
+                                    jigsawBlockTargetPos.getZ() - candidateJigsawBlockPos.getZ()
+                            );
 
                             // Get the bounding box for the piece, offset by the relative position difference
-                            BoundingBox candidateBoundingBox = candidatePiece.getBoundingBox(context.structureTemplateManager(), candidateJigsawBlockRelativePos, rotation);
+                            BoundingBox candidateBoundingBox =
+                                    candidatePiece.getBoundingBox(context.structureTemplateManager(), candidateJigsawBlockRelativePos, rotation);
 
-                            // Determine if candidate is rigid
                             StructureTemplatePool.Projection candidatePlacementBehavior = candidatePiece.getProjection();
                             boolean isCandidateRigid = candidatePlacementBehavior == StructureTemplatePool.Projection.RIGID;
                             boolean isCandidatePieceOceanFloor = candidatePiece instanceof LegacyOceanBottomSinglePoolElement;
 
-                            // Determine how much the candidate jigsaw block is off in the y direction.
-                            // This will be needed to offset the candidate piece so that the jigsaw blocks line up properly.
                             int candidateJigsawBlockRelativeY = candidateJigsawBlockPos.getY();
-                            int candidateJigsawYOffsetNeeded = jigsawBlockRelativeY - candidateJigsawBlockRelativeY + JigsawBlock.getFrontFacing(jigsawBlock.info().state()).getStepY();
+                            int candidateJigsawYOffsetNeeded =
+                                    jigsawBlockRelativeY - candidateJigsawBlockRelativeY + JigsawBlock.getFrontFacing(jigsawBlock.info().state()).getStepY();
 
                             // Determine how much we need to offset the candidate piece itself in order to have the jigsaw blocks aligned.
                             // Depends on if the placement of both pieces is rigid or not
                             int adjustedCandidatePieceMinY;
                             if (isPieceRigid && !isPieceOceanFloor && isCandidateRigid && !isCandidatePieceOceanFloor) {
                                 adjustedCandidatePieceMinY = pieceMinY + candidateJigsawYOffsetNeeded;
-                            }
-                            else {
+                            } else {
                                 if (surfaceHeight == -1) {
-                                    surfaceHeight = context.chunkGenerator().getFirstFreeHeight(jigsawBlockPos.getX(), jigsawBlockPos.getZ(), isCandidatePieceOceanFloor || isPieceOceanFloor ? Heightmap.Types.OCEAN_FLOOR_WG : Heightmap.Types.WORLD_SURFACE_WG, heightLimitView, context.randomState());
+                                    surfaceHeight = context.chunkGenerator().getFirstFreeHeight(
+                                            jigsawBlockPos.getX(), jigsawBlockPos.getZ(),
+                                            (isCandidatePieceOceanFloor || isPieceOceanFloor) ? Heightmap.Types.OCEAN_FLOOR_WG : Heightmap.Types.WORLD_SURFACE_WG,
+                                            heightLimitView, context.randomState());
                                 }
 
                                 adjustedCandidatePieceMinY = surfaceHeight - candidateJigsawBlockRelativeY;
@@ -512,7 +600,7 @@ public class PieceLimitedJigsawManager {
 
                             // Final adjustments to the bounding box.
                             if (candidateHeightAdjustments > 0) {
-                                int k2 = Math.max(candidateHeightAdjustments + 1, adjustedCandidateBoundingBox.maxY() - adjustedCandidateBoundingBox.minY());
+                                int k2 = Math.max(candidateHeightAdjustments + 1, adjustedCandidateBoundingBox.getYSpan());
                                 adjustedCandidateBoundingBox.encapsulate(new BlockPos(adjustedCandidateBoundingBox.minX(), adjustedCandidateBoundingBox.minY() + k2, adjustedCandidateBoundingBox.minZ()));
                             }
 
@@ -526,20 +614,18 @@ public class PieceLimitedJigsawManager {
                             boolean validBounds = false;
 
                             // Make sure new piece fits within the chosen octree without intersecting any other piece.
-                            if (ignoreBounds || (boxOctreeMutableObject.getValue().boundaryContains(axisAlignedBBDeflated) && !boxOctreeMutableObject.getValue().intersectsAnyBox(axisAlignedBBDeflated))) {
+                            if (ignoreBounds || (boxOctreeMutableObject.getValue().boundaryContains(axisAlignedBBDeflated)
+                                    && !boxOctreeMutableObject.getValue().intersectsAnyBox(axisAlignedBBDeflated))) {
                                 boxOctreeMutableObject.getValue().addBox(axisAlignedBB);
                                 validBounds = true;
                             }
 
                             if (validBounds) {
-
-                                // Determine ground level delta for this new piece
                                 int newPieceGroundLevelDelta = piece.getGroundLevelDelta();
                                 int groundLevelDelta;
                                 if (isCandidateRigid && !isCandidatePieceOceanFloor) {
                                     groundLevelDelta = newPieceGroundLevelDelta - candidateJigsawYOffsetNeeded;
-                                }
-                                else {
+                                } else {
                                     groundLevelDelta = candidatePiece.getGroundLevelDelta();
                                 }
 
@@ -558,37 +644,33 @@ public class PieceLimitedJigsawManager {
                                 int candidateJigsawBlockY;
                                 if (isPieceRigid && !isPieceOceanFloor) {
                                     candidateJigsawBlockY = pieceMinY + jigsawBlockRelativeY;
-                                }
-                                else if (isCandidateRigid && !isCandidatePieceOceanFloor) {
+                                } else if (isCandidateRigid && !isCandidatePieceOceanFloor) {
                                     candidateJigsawBlockY = adjustedCandidatePieceMinY + candidateJigsawBlockRelativeY;
-                                }
-                                else {
+                                } else {
                                     if (surfaceHeight == -1) {
-                                        surfaceHeight = context.chunkGenerator().getFirstFreeHeight(jigsawBlockPos.getX(), jigsawBlockPos.getZ(), isCandidatePieceOceanFloor || isPieceOceanFloor ? Heightmap.Types.OCEAN_FLOOR_WG : Heightmap.Types.WORLD_SURFACE_WG, heightLimitView, context.randomState());
+                                        surfaceHeight = context.chunkGenerator().getFirstFreeHeight(
+                                                jigsawBlockPos.getX(), jigsawBlockPos.getZ(),
+                                                (isCandidatePieceOceanFloor || isPieceOceanFloor) ? Heightmap.Types.OCEAN_FLOOR_WG : Heightmap.Types.WORLD_SURFACE_WG,
+                                                heightLimitView, context.randomState());
                                     }
-
                                     candidateJigsawBlockY = surfaceHeight + candidateJigsawYOffsetNeeded / 2;
                                 }
 
                                 // Add the junction to the existing piece
-                                piece.addJunction(
-                                        new JigsawJunction(
-                                                jigsawBlockTargetPos.getX(),
-                                                candidateJigsawBlockY - jigsawBlockRelativeY + newPieceGroundLevelDelta,
-                                                jigsawBlockTargetPos.getZ(),
-                                                candidateJigsawYOffsetNeeded,
-                                                candidatePlacementBehavior)
-                                );
+                                piece.addJunction(new JigsawJunction(
+                                        jigsawBlockTargetPos.getX(),
+                                        candidateJigsawBlockY - jigsawBlockRelativeY + newPieceGroundLevelDelta,
+                                        jigsawBlockTargetPos.getZ(),
+                                        candidateJigsawYOffsetNeeded,
+                                        piecePlacementBehavior));
 
                                 // Add the junction to the new piece
-                                newPiece.addJunction(
-                                        new JigsawJunction(
-                                                jigsawBlockPos.getX(),
-                                                candidateJigsawBlockY - candidateJigsawBlockRelativeY + groundLevelDelta,
-                                                jigsawBlockPos.getZ(),
-                                                -candidateJigsawYOffsetNeeded,
-                                                piecePlacementBehavior)
-                                );
+                                newPiece.addJunction(new JigsawJunction(
+                                        jigsawBlockPos.getX(),
+                                        candidateJigsawBlockY - candidateJigsawBlockRelativeY + groundLevelDelta,
+                                        jigsawBlockPos.getZ(),
+                                        -candidateJigsawYOffsetNeeded,
+                                        piecePlacementBehavior));
 
                                 // Add the piece
                                 this.structurePieces.add(newPiece);


### PR DESCRIPTION
The way we were looking up registries changed, but didn't throw any lint errors.

Updated for new registry system. This change might go back as far as 1.21.1 or 1.21.2

Issue #4 