### PR TITLE
Rewrite hanging-entity TileX/Y/Z anchors at placement time (1.20.5–1.20.6)

### DIFF
--- a/common/src/main/java/com/finndog/moogs_structures/modinit/MoogsStructuresProcessors.java
+++ b/common/src/main/java/com/finndog/moogs_structures/modinit/MoogsStructuresProcessors.java
@@ -7,6 +7,7 @@ import com.finndog.moogs_structures.modinit.registry.ResourcefulRegistry;
 import com.finndog.moogs_structures.world.processors.CloseOffFluidSourcesProcessor;
 import com.finndog.moogs_structures.world.processors.EquipArmorStandProcessor;
 import com.finndog.moogs_structures.world.processors.FloodWithWaterProcessor;
+import com.finndog.moogs_structures.world.processors.HangingEntityAnchorProcessor;
 import com.finndog.moogs_structures.world.processors.PillarProcessor;
 import com.finndog.moogs_structures.world.processors.RandomReplaceWithPropertiesProcessor;
 import com.finndog.moogs_structures.world.processors.RemoveFloatingBlocksProcessor;
@@ -29,5 +30,6 @@ public final class MoogsStructuresProcessors {
     public static final RegistryEntry<StructureProcessorType<SpawnerRandomizingProcessor>> SPAWNER_RANDOMIZING_PROCESSOR = STRUCTURE_PROCESSOR.register("spawner_randomizing_processor", () -> () -> SpawnerRandomizingProcessor.CODEC);
     public static final RegistryEntry<StructureProcessorType<EquipArmorStandProcessor>> EQUIP_ARMOR_STAND_PROCESSOR = STRUCTURE_PROCESSOR.register("equip_armor_stand_processor", () -> () -> EquipArmorStandProcessor.CODEC);
     public static final RegistryEntry<StructureProcessorType<WaterloggingFixProcessor>> WATERLOGGING_FIX_PROCESSOR = STRUCTURE_PROCESSOR.register("waterlogging_fix_processor", () -> () -> WaterloggingFixProcessor.CODEC);
+    public static final RegistryEntry<StructureProcessorType<HangingEntityAnchorProcessor>> HANGING_ENTITY_ANCHOR_PROCESSOR = STRUCTURE_PROCESSOR.register("hanging_entity_anchor_processor", () -> () -> HangingEntityAnchorProcessor.CODEC);
     public static final RegistryEntry<StructureProcessorType<VanillaLootSwapProcessor>> VANILLA_LOOT_SWAP_PROCESSOR = STRUCTURE_PROCESSOR.register("vanilla_loot_swap_processor", () -> () -> VanillaLootSwapProcessor.CODEC);
 }

--- a/common/src/main/java/com/finndog/moogs_structures/world/processors/HangingEntityAnchorProcessor.java
+++ b/common/src/main/java/com/finndog/moogs_structures/world/processors/HangingEntityAnchorProcessor.java
@@ -1,0 +1,68 @@
+package com.finndog.moogs_structures.world.processors;
+
+import com.finndog.moogs_structures.modinit.MoogsStructuresProcessors;
+import com.mojang.serialization.Codec;
+import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.world.level.ServerLevelAccessor;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorType;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructureTemplate;
+
+import java.util.Set;
+
+/**
+ * Rewrites hanging-entity anchors ({@code TileX/TileY/TileZ}) to the entity's placed world
+ * position as a structure is placed.
+ *
+ * <p>Pre-1.21 hanging entities (item frames, paintings, leash knots) store their anchor as
+ * absolute world coordinates in NBT, but template placement only rewrites {@code Pos} — so any
+ * template-authored anchor is stale at every placement site, fails the ~16-block sanity check in
+ * {@code HangingEntity#readAdditionalSaveData}, and logs
+ * {@code Hanging entity at invalid position} once per placed entity (the entity itself survives:
+ * its anchor is re-derived from {@code Pos}). Even templates saved by a vanilla structure block
+ * carry the authoring world's coordinates and log this. 1.21+ removed the fields and derives the
+ * anchor from the entity position, which is the behavior this processor gives the pre-1.21 path.
+ *
+ * <p>{@code VersionAwareSinglePoolElement} appends this processor to every placement it drives, so
+ * versioned structures get it with no datapack changes; other pieces can opt in via
+ * {@code moogs_structures:hanging_entity_anchor_processor} in a processor list.
+ */
+public class HangingEntityAnchorProcessor extends StructureEntityProcessor {
+
+    public static final HangingEntityAnchorProcessor INSTANCE = new HangingEntityAnchorProcessor();
+    public static final Codec<HangingEntityAnchorProcessor> CODEC = Codec.unit(() -> INSTANCE);
+
+    private static final Set<String> HANGING_ENTITY_IDS = Set.of(
+            "minecraft:item_frame",
+            "minecraft:glow_item_frame",
+            "minecraft:painting",
+            "minecraft:leash_knot"
+    );
+
+    private HangingEntityAnchorProcessor() { }
+
+    @Override
+    public StructureTemplate.StructureEntityInfo processEntity(ServerLevelAccessor serverLevelAccessor,
+                                                               BlockPos structurePiecePos,
+                                                               BlockPos structurePieceBottomCenterPos,
+                                                               StructureTemplate.StructureEntityInfo localEntityInfo,
+                                                               StructureTemplate.StructureEntityInfo globalEntityInfo,
+                                                               StructurePlaceSettings structurePlaceSettings) {
+        CompoundTag nbt = globalEntityInfo.nbt;
+        if (nbt == null || !HANGING_ENTITY_IDS.contains(nbt.getString("id"))) {
+            return globalEntityInfo;
+        }
+        BlockPos anchor = globalEntityInfo.blockPos;
+        CompoundTag newNbt = nbt.copy();
+        newNbt.putInt("TileX", anchor.getX());
+        newNbt.putInt("TileY", anchor.getY());
+        newNbt.putInt("TileZ", anchor.getZ());
+        return new StructureTemplate.StructureEntityInfo(globalEntityInfo.pos, globalEntityInfo.blockPos, newNbt);
+    }
+
+    @Override
+    protected StructureProcessorType<?> getType() {
+        return MoogsStructuresProcessors.HANGING_ENTITY_ANCHOR_PROCESSOR.get();
+    }
+}

--- a/common/src/main/java/com/finndog/moogs_structures/world/structures/pieces/VersionAwareSinglePoolElement.java
+++ b/common/src/main/java/com/finndog/moogs_structures/world/structures/pieces/VersionAwareSinglePoolElement.java
@@ -6,6 +6,7 @@ import com.finndog.moogs_structures.utils.DebugFlags;
 import com.finndog.moogs_structures.utils.VersionResolver;
 import com.finndog.moogs_structures.utils.VersionResolver.VersionEntry;
 import com.finndog.moogs_structures.utils.VersionResolver.VersionNumber;
+import com.finndog.moogs_structures.world.processors.HangingEntityAnchorProcessor;
 import com.mojang.datafixers.util.Either;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
@@ -15,6 +16,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.levelgen.structure.pools.SinglePoolElement;
 import net.minecraft.world.level.levelgen.structure.pools.StructurePoolElementType;
 import net.minecraft.world.level.levelgen.structure.pools.StructureTemplatePool;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.levelgen.structure.BoundingBox;
+import net.minecraft.world.level.levelgen.structure.templatesystem.StructurePlaceSettings;
 import net.minecraft.world.level.levelgen.structure.templatesystem.StructureProcessorList;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -140,6 +144,18 @@ public class VersionAwareSinglePoolElement extends SinglePoolElement {
 
     private Optional<ResourceLocation> singleLocation() {
         return Optional.ofNullable(this.singleLocation);
+    }
+
+    /**
+     * Pre-1.21 hanging entities need their {@code TileX/Y/Z} anchor rewritten to world
+     * coordinates at placement time (see {@link HangingEntityAnchorProcessor}); appending the
+     * processor here gives every versioned structure the fix with no datapack changes.
+     */
+    @Override
+    protected StructurePlaceSettings getSettings(Rotation rotation, BoundingBox boundingBox, boolean replaceJigsaw) {
+        StructurePlaceSettings settings = super.getSettings(rotation, boundingBox, replaceJigsaw);
+        settings.addProcessor(HangingEntityAnchorProcessor.INSTANCE);
+        return settings;
     }
 
     @Override


### PR DESCRIPTION
Closes #14 (together with #15 — this is the same commit cherry-picked onto the `1.20.5-1.20.6` branch; it applied cleanly, and the surrounding API idioms are identical on both branches).

See #15 for the full rationale and design: `HangingEntityAnchorProcessor` rewrites `TileX/TileY/TileZ` to the entity's transformed world position before creation, `VersionAwareSinglePoolElement#getSettings` appends it unconditionally, loader wiring already exists.

Same verification caveat as #15: ⚠️ needs one local `gradlew build` before merge. In-game acceptance on a 1.20.5/1.20.6 instance: zero `Hanging entity at invalid position` lines from placed structures, item frames present with their contents.